### PR TITLE
improved instructions on adding the Affectiva SDK

### DIFF
--- a/AffdexMe/app/src/main/java/com/affectiva/affdexme/MainActivity.java
+++ b/AffdexMe/app/src/main/java/com/affectiva/affdexme/MainActivity.java
@@ -52,10 +52,10 @@ import java.util.List;
  * In order to use this project, you will need to:
  * - Obtain the SDK from Affectiva (visit http://www.affdex.com/mobile-sdk)
  * - Copy the SDK assets folder contents into this project's assets folder
- * - Copy the SDK libs folder contents into this project's libs folder
- * - Copy the armeabi-v7a folder (found in the SDK libs folder) into this project's jniLibs folder
- * - Add your license file to the /assets/Affdex folder and uncomment the line in the startCamera() method
- * to type in your license file name
+ * - Copy the contents of the SDK's libs folder into this project's libs folder under AffdexMe/app/lib
+ * - Copy the armeabi-v7a folder (found in the SDK libs folder) into this project's jniLibs folder under AffdexMe/app/src/main/jniLibs
+ * - Add your license file to the /assets/Affdex folder and rename to license.txt. 
+ * (Note: if you name the license file something else you will need to update the licensePath in the initializeCameraDetector() method in MainActivity)
  * - Build the project
  * - Run the app on an Android device with a front-facing camera
  *
@@ -213,7 +213,9 @@ public class MainActivity extends Activity
          * that view will be painted with what the camera sees.
          */
         detector = new CameraDetector(this, CameraDetector.CameraType.CAMERA_FRONT, cameraView);
-        detector.setLicensePath("YourLicenseFile");
+
+		// update the license path here if you name your file something else
+        detector.setLicensePath("license.txt");
         detector.setImageListener(this);
         detector.setFaceListener(this);
         detector.setCameraDetectorDimensionsListener(this);

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The AffdexMe folder is an Android Studio project.
 In order to use this project, you will need to:
 - Obtain the Affectiva Android SDK 
 - Copy the contents of the SDK's assets folder into this project's assets folder
-- Copy the contents of the SDK's libs folder into this project's libs folder
-- Copy the armeabi-v7a folder (found in the SDK libs folder) into this project's jniLibs folder
-- Add your license file to the /assets/Affdex folder and uncomment the line in the startCamera() method which specifies your license file path
+- Copy the contents of the SDK's libs folder into this project's libs folder under AffdexMe/app/lib
+- Copy the armeabi-v7a folder (found in the SDK libs folder) into this project's jniLibs folder under AffdexMe/app/src/main/jniLibs
+- Add your license file to the /assets/Affdex folder and rename to license.txt. (Note: if you name the license file something else you will need to update the licensePath in the initializeCameraDetector() method in MainActivity)
 - Build the project
 - Run the app on an Android device with a front-facing camera
 


### PR DESCRIPTION
Trivial documentation changes
I had some issues with where the jni library should be placed so thought it was beneficial to provide the actual paths
I think including a preferred name for the license file makes it possible to get the project to build with no code changes.